### PR TITLE
feat: Implement VSS integration for SwatchRepository::save_swatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastembed"
 version = "4.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,6 +2448,7 @@ dependencies = [
  "futures",
  "log",
  "mockall",
+ "rusqlite",
  "serde",
  "serde_json",
  "sqlite-vec",
@@ -2448,6 +2461,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2730,6 +2744,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+dependencies = [
+ "bitflags 2.9.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4521,6 +4549,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,13 @@ text-splitter = "0.25.1"
 async-trait = "0.1.88"
 # SQLite database
 sqlx = { version = "0.7.4", features = ["sqlite", "runtime-tokio-rustls", "time"] }
+# Need rusqlite explicitly for FFI access with the 'bundled' feature for auto_extension
+# Version 0.30.0 uses libsqlite3-sys ^0.27, compatible with sqlx's ^0.27 requirement
+rusqlite = { version = "0.30.0", features = ["bundled"] }
 # SQLite vector extension for similarity search
 sqlite-vec = "0.1.6"
+# Efficiently pass vector bytes
+zerocopy = "0.7" # Adjust version if needed
 # JSON serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,9 +1,7 @@
 //! Database utilities for SQLite setup and connection management
 
-use rusqlite::{Connection, Result as SqliteResult};
 use sqlite_vec; // Import the sqlite_vec crate
 use sqlx::{migrate::MigrateDatabase, sqlite::SqlitePoolOptions, Sqlite, SqlitePool};
-use std::path::Path;
 use std::sync::Once;
 use tracing::{debug, info};
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,11 +1,11 @@
 //! Database utilities for SQLite setup and connection management
 
-use sqlx::{migrate::MigrateDatabase, sqlite::SqlitePoolOptions, Sqlite, SqlitePool};
-use std::sync::Once;
-use tracing::{debug, info};
 use rusqlite::{Connection, Result as SqliteResult};
 use sqlite_vec; // Import the sqlite_vec crate
+use sqlx::{migrate::MigrateDatabase, sqlite::SqlitePoolOptions, Sqlite, SqlitePool};
 use std::path::Path;
+use std::sync::Once;
+use tracing::{debug, info};
 
 // Global static for ensuring one-time initialization of the sqlite-vec extension.
 static SQLITE_VEC_INIT: Once = Once::new();

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,9 @@
 use sqlx::{migrate::MigrateDatabase, sqlite::SqlitePoolOptions, Sqlite, SqlitePool};
 use std::sync::Once;
 use tracing::{debug, info};
+use rusqlite::{Connection, Result as SqliteResult};
+use sqlite_vec; // Import the sqlite_vec crate
+use std::path::Path;
 
 // Global static for ensuring one-time initialization of the sqlite-vec extension.
 static SQLITE_VEC_INIT: Once = Once::new();
@@ -19,7 +22,7 @@ fn register_sqlite_vec_globally() {
         unsafe {
             // Use the rusqlite::ffi module directly for sqlite3_auto_extension
             match rusqlite::ffi::sqlite3_auto_extension(Some(
-                std::mem::transmute(sqlite_vec::sqlite3_vec_init as *const ()),
+                std::mem::transmute::<*const (), unsafe extern "C" fn(*mut rusqlite::ffi::sqlite3, *mut *const i8, *const rusqlite::ffi::sqlite3_api_routines) -> i32>(sqlite_vec::sqlite3_vec_init as *const ()),
             )) {
                 rusqlite::ffi::SQLITE_OK => {
                     // Use eprintln! here as tracing might not be initialized yet.

--- a/src/swatching/sqlite_repository.rs
+++ b/src/swatching/sqlite_repository.rs
@@ -747,7 +747,7 @@ mod tests {
         let mut s = Swatch::new(
             cut_id.to_string(),
             material_id.to_string(),
-            vec![0.1; 384], // Use 384 dimensions to match VSS schema
+            vec![0.1; 384],
             "test-model".to_string(),
             "v1.0".to_string(),
         );

--- a/src/swatching/sqlite_repository.rs
+++ b/src/swatching/sqlite_repository.rs
@@ -390,7 +390,6 @@ impl SwatchRepository for SqliteSwatchRepository {
             let metadata_for_query = metadata_json.clone();
 
             Box::pin(async move {
-                // First, save to the main swatches table
                 let main_save_result = Self::execute_save_swatch_query(
                     tx,
                     &swatch_id,

--- a/src/swatching/sqlite_repository.rs
+++ b/src/swatching/sqlite_repository.rs
@@ -315,7 +315,9 @@ impl SqliteSwatchRepository {
         metadata_json: &Option<String>,
         similarity_threshold: Option<f32>,
     ) -> std::result::Result<sqlx::sqlite::SqliteQueryResult, sqlx::Error> {
-        let result = sqlx::query(
+        
+
+        sqlx::query(
             r#"
             INSERT INTO swatches (
                 id, cut_id, material_id, embedding, model_name, model_version, 
@@ -344,9 +346,7 @@ impl SqliteSwatchRepository {
         .bind(metadata_json)
         .bind(similarity_threshold)
         .execute(&mut **tx)
-        .await;
-
-        result
+        .await
     }
 }
 
@@ -741,7 +741,7 @@ mod tests {
     use crate::db::init_memory_db;
     use crate::materials::{Material, MaterialRepository, SqliteMaterialRepository};
     use serde_json::json;
-    use time::Duration;
+    
 
     // Helper to create a test pool
     async fn setup() -> SqlitePool {

--- a/src/swatching/sqlite_repository.rs
+++ b/src/swatching/sqlite_repository.rs
@@ -345,7 +345,7 @@ impl SqliteSwatchRepository {
         .bind(similarity_threshold)
         .execute(&mut **tx)
         .await;
-        
+
         result
     }
 }
@@ -404,23 +404,30 @@ impl SwatchRepository for SqliteSwatchRepository {
                     similarity_threshold,
                 )
                 .await?;
-                
+
                 // Get the rowid of the inserted/updated swatch using swatch_id
-                let rowid_res: sqlx::Result<(i64,)> = sqlx::query_as("SELECT rowid FROM swatches WHERE id = ?")
-                    .bind(&swatch_id)
-                    .fetch_one(&mut **tx)
-                    .await;
-                
+                let rowid_res: sqlx::Result<(i64,)> =
+                    sqlx::query_as("SELECT rowid FROM swatches WHERE id = ?")
+                        .bind(&swatch_id)
+                        .fetch_one(&mut **tx)
+                        .await;
+
                 let row_id = match rowid_res {
                     Ok((id,)) => id,
                     Err(e) => {
-                        error!("Failed to fetch rowid for swatch {}: {}. Cannot update VSS.", swatch_id, e);
+                        error!(
+                            "Failed to fetch rowid for swatch {}: {}. Cannot update VSS.",
+                            swatch_id, e
+                        );
                         // Propagate the error to rollback the transaction
                         return Err(e);
                     }
                 };
 
-                debug!("Swatch {} saved/updated. Found rowid: {} for VSS update.", swatch_id, row_id);
+                debug!(
+                    "Swatch {} saved/updated. Found rowid: {} for VSS update.",
+                    swatch_id, row_id
+                );
 
                 // Attempt to update the VSS table using the fetched rowid
                 debug!("Attempting VSS update for rowid: {}", row_id);
@@ -461,7 +468,7 @@ impl SwatchRepository for SqliteSwatchRepository {
 
                 // Return success from the transaction block if main save was ok
                 // The `?` operator above handles the error case for the main save.
-                Ok(main_save_result) 
+                Ok(main_save_result)
             })
         })
         .await
@@ -813,19 +820,23 @@ mod tests {
                 // Try fetching as Vec<u8> first
                 let embedding_bytes_res: std::result::Result<Vec<u8>, _> = row.try_get("embedding");
                 if let Ok(bytes) = embedding_bytes_res {
-                     match bytes_to_f32_vec(&bytes) {
-                         Ok(vec) => Some(vec),
-                         Err(e) => {
-                             eprintln!("Failed to deserialize VSS embedding bytes for rowid {}: {}", swatch_rowid, e);
-                             None
-                         }
-                     }
+                    match bytes_to_f32_vec(&bytes) {
+                        Ok(vec) => Some(vec),
+                        Err(e) => {
+                            eprintln!(
+                                "Failed to deserialize VSS embedding bytes for rowid {}: {}",
+                                swatch_rowid, e
+                            );
+                            None
+                        }
+                    }
                 } else {
-                     eprintln!(
-                         "Failed to retrieve VSS embedding as bytes for rowid {}: {}",
-                         swatch_rowid, embedding_bytes_res.unwrap_err()
-                     );
-                     None
+                    eprintln!(
+                        "Failed to retrieve VSS embedding as bytes for rowid {}: {}",
+                        swatch_rowid,
+                        embedding_bytes_res.unwrap_err()
+                    );
+                    None
                 }
             }
             Ok(None) => None,
@@ -838,12 +849,13 @@ mod tests {
             }
         }
     }
-    
+
     #[tokio::test]
     async fn test_save_and_get_swatch() {
         let pool = setup().await;
         let swatch_repo = SqliteSwatchRepository::new(pool.clone());
-        let (_material_repo, _cuts_repo, material_id, cut_id) = insert_test_dependencies(&pool, "save-get", 0).await;
+        let (_material_repo, _cuts_repo, material_id, cut_id) =
+            insert_test_dependencies(&pool, "save-get", 0).await;
         let swatch = create_test_swatch(&cut_id, &material_id);
         let swatch_id = swatch.id.clone();
         let original_embedding = swatch.embedding.clone();
@@ -864,12 +876,24 @@ mod tests {
             .bind(&swatch_id)
             .fetch_one(&pool)
             .await;
-        assert!(rowid_result.is_ok(), "Failed to get rowid: {:?}", rowid_result.err());
+        assert!(
+            rowid_result.is_ok(),
+            "Failed to get rowid: {:?}",
+            rowid_result.err()
+        );
         let rowid: i64 = rowid_result.unwrap().get("rowid");
 
         let vss_embedding = get_vss_embedding(&pool, rowid).await;
-        assert!(vss_embedding.is_some(), "VSS embedding not found for rowid {}", rowid);
-        assert_eq!(vss_embedding.unwrap(), original_embedding, "VSS embedding does not match original");
+        assert!(
+            vss_embedding.is_some(),
+            "VSS embedding not found for rowid {}",
+            rowid
+        );
+        assert_eq!(
+            vss_embedding.unwrap(),
+            original_embedding,
+            "VSS embedding does not match original"
+        );
     }
 
     #[tokio::test]
@@ -916,26 +940,43 @@ mod tests {
     async fn test_save_swatch_upsert() {
         let pool = setup().await;
         let swatch_repo = SqliteSwatchRepository::new(pool.clone());
-        let (_material_repo, _cuts_repo, material_id, cut_id) = insert_test_dependencies(&pool, "upsert", 0).await;
+        let (_material_repo, _cuts_repo, material_id, cut_id) =
+            insert_test_dependencies(&pool, "upsert", 0).await;
         let mut swatch1 = create_test_swatch(&cut_id, &material_id);
         let swatch_id = swatch1.id.clone(); // Use the same ID for both
         let original_embedding = swatch1.embedding.clone();
 
         // Save the first version
         let save1_result = swatch_repo.save_swatch(&swatch1).await;
-        assert!(save1_result.is_ok(), "Save 1 failed: {:?}", save1_result.err());
+        assert!(
+            save1_result.is_ok(),
+            "Save 1 failed: {:?}",
+            save1_result.err()
+        );
 
         // Verify VSS after first save
         let rowid_result1 = sqlx::query("SELECT rowid FROM swatches WHERE id = ?")
             .bind(&swatch_id)
             .fetch_one(&pool)
             .await;
-        assert!(rowid_result1.is_ok(), "Failed to get rowid 1: {:?}", rowid_result1.err());
+        assert!(
+            rowid_result1.is_ok(),
+            "Failed to get rowid 1: {:?}",
+            rowid_result1.err()
+        );
         let rowid1: i64 = rowid_result1.unwrap().get("rowid");
-        
+
         let vss_embedding1 = get_vss_embedding(&pool, rowid1).await;
-        assert!(vss_embedding1.is_some(), "VSS embedding not found after first save for rowid {}", rowid1);
-        assert_eq!(vss_embedding1.unwrap(), original_embedding, "VSS embedding does not match original after first save");
+        assert!(
+            vss_embedding1.is_some(),
+            "VSS embedding not found after first save for rowid {}",
+            rowid1
+        );
+        assert_eq!(
+            vss_embedding1.unwrap(),
+            original_embedding,
+            "VSS embedding does not match original after first save"
+        );
 
         // Modify the swatch (e.g., change embedding)
         let updated_embedding = vec![0.9; 384]; // Use 384 dimensions
@@ -943,25 +984,48 @@ mod tests {
 
         // Save the second version (upsert)
         let save2_result = swatch_repo.save_swatch(&swatch1).await;
-        assert!(save2_result.is_ok(), "Save 2 failed: {:?}", save2_result.err());
+        assert!(
+            save2_result.is_ok(),
+            "Save 2 failed: {:?}",
+            save2_result.err()
+        );
 
         // Retrieve the updated swatch
-        let retrieved = swatch_repo.get_swatch_by_id(&swatch_id).await.unwrap().unwrap();
+        let retrieved = swatch_repo
+            .get_swatch_by_id(&swatch_id)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(retrieved.id, swatch_id);
-        assert_eq!(retrieved.embedding, updated_embedding, "Swatch embedding was not updated");
-        
+        assert_eq!(
+            retrieved.embedding, updated_embedding,
+            "Swatch embedding was not updated"
+        );
+
         // Verify VSS after second save (should use same rowid)
-         let rowid_result2 = sqlx::query("SELECT rowid FROM swatches WHERE id = ?")
+        let rowid_result2 = sqlx::query("SELECT rowid FROM swatches WHERE id = ?")
             .bind(&swatch_id)
             .fetch_one(&pool)
             .await;
-        assert!(rowid_result2.is_ok(), "Failed to get rowid 2: {:?}", rowid_result2.err());
+        assert!(
+            rowid_result2.is_ok(),
+            "Failed to get rowid 2: {:?}",
+            rowid_result2.err()
+        );
         let rowid2: i64 = rowid_result2.unwrap().get("rowid");
         assert_eq!(rowid2, rowid1, "Rowid changed during upsert"); // Ensure rowid remains stable
 
         let vss_embedding2 = get_vss_embedding(&pool, rowid2).await;
-        assert!(vss_embedding2.is_some(), "VSS embedding not found after second save for rowid {}", rowid2);
-        assert_eq!(vss_embedding2.unwrap(), updated_embedding, "VSS embedding does not match updated embedding after second save");
+        assert!(
+            vss_embedding2.is_some(),
+            "VSS embedding not found after second save for rowid {}",
+            rowid2
+        );
+        assert_eq!(
+            vss_embedding2.unwrap(),
+            updated_embedding,
+            "VSS embedding does not match updated embedding after second save"
+        );
     }
 
     #[tokio::test]

--- a/src/swatching/sqlite_repository.rs
+++ b/src/swatching/sqlite_repository.rs
@@ -17,7 +17,8 @@ fn f32_vec_to_bytes(vec: &[f32]) -> Vec<u8> {
 }
 
 // Helper function to deserialize Vec<u8> to Vec<f32>
-fn bytes_to_f32_vec(bytes: &[u8]) -> std::result::Result<Vec<f32>, String> {
+// Made public for use in test helpers
+pub(crate) fn bytes_to_f32_vec(bytes: &[u8]) -> std::result::Result<Vec<f32>, String> {
     let float_size = std::mem::size_of::<f32>();
     if bytes.len() % float_size != 0 {
         return Err("Invalid byte slice length for f32 deserialization".to_string());
@@ -314,7 +315,7 @@ impl SqliteSwatchRepository {
         metadata_json: &Option<String>,
         similarity_threshold: Option<f32>,
     ) -> std::result::Result<sqlx::sqlite::SqliteQueryResult, sqlx::Error> {
-        sqlx::query(
+        let result = sqlx::query(
             r#"
             INSERT INTO swatches (
                 id, cut_id, material_id, embedding, model_name, model_version, 
@@ -343,7 +344,10 @@ impl SqliteSwatchRepository {
         .bind(metadata_json)
         .bind(similarity_threshold)
         .execute(&mut **tx)
-        .await
+        .await;
+        
+        // Explicitly return only the query result, rowid handling moved to save_swatch
+        result
     }
 }
 
@@ -387,7 +391,8 @@ impl SwatchRepository for SqliteSwatchRepository {
             let metadata_for_query = metadata_json.clone();
 
             Box::pin(async move {
-                Self::execute_save_swatch_query(
+                // First, save to the main swatches table
+                let main_save_result = Self::execute_save_swatch_query(
                     tx,
                     &swatch_id,
                     &cut_id,
@@ -400,7 +405,52 @@ impl SwatchRepository for SqliteSwatchRepository {
                     &metadata_for_query,
                     similarity_threshold,
                 )
-                .await
+                .await?;
+                
+                // Get the rowid of the inserted/updated swatch
+                let last_row_id = main_save_result.last_insert_rowid();
+                debug!("Swatch {} saved/updated with rowid: {}", swatch_id, last_row_id);
+
+                // Attempt to update the VSS table using the rowid
+                debug!("Attempting VSS update for rowid: {}", last_row_id);
+
+                // Delete existing entry in vss_swatches (if any)
+                let delete_res = sqlx::query("DELETE FROM vss_swatches WHERE rowid = ?")
+                    .bind(last_row_id)
+                    .execute(&mut **tx)
+                    .await;
+
+                if let Err(e) = delete_res {
+                    // Log non-fatal error for VSS delete
+                    debug!(
+                        "Failed VSS delete for rowid {}: {}. Continuing transaction.",
+                        last_row_id, e
+                    );
+                } else {
+                    debug!("VSS delete successful or rowid {} not found.", last_row_id);
+                }
+
+                // Insert new entry into vss_swatches
+                let insert_res =
+                    sqlx::query("INSERT INTO vss_swatches (rowid, embedding) VALUES (?, ?)")
+                        .bind(last_row_id)
+                        .bind(&embedding_bytes) // Use original embedding_bytes
+                        .execute(&mut **tx)
+                        .await;
+
+                if let Err(e) = insert_res {
+                    // Log non-fatal error for VSS insert
+                    debug!(
+                        "Failed VSS insert for rowid {}: {}. Continuing transaction.",
+                        last_row_id, e
+                    );
+                } else {
+                    debug!("VSS insert successful for rowid {}.", last_row_id);
+                }
+
+                // Return success from the transaction block if main save was ok
+                // The `?` operator above handles the error case for the main save.
+                Ok(main_save_result) 
             })
         })
         .await
@@ -686,7 +736,7 @@ mod tests {
         let mut s = Swatch::new(
             cut_id.to_string(),
             material_id.to_string(),
-            vec![0.1, 0.2, 0.3],
+            vec![0.1; 384], // Use 384 dimensions to match VSS schema
             "test-model".to_string(),
             "v1.0".to_string(),
         );
@@ -738,38 +788,77 @@ mod tests {
         (material_repo, cuts_repo, material_id, cut_id)
     }
 
+    // Helper to fetch VSS embedding for verification
+    async fn get_vss_embedding(pool: &SqlitePool, swatch_rowid: i64) -> Option<Vec<f32>> {
+        // Query vss_swatches directly using the integer rowid
+        let result = sqlx::query("SELECT embedding FROM vss_swatches WHERE rowid = ?")
+            .bind(swatch_rowid)
+            .fetch_optional(pool)
+            .await;
+
+        match result {
+            Ok(Some(row)) => {
+                // Note: sqlite-vec stores the vector directly, not blob necessarily
+                // Try fetching as Vec<u8> first
+                let embedding_bytes_res: std::result::Result<Vec<u8>, _> = row.try_get("embedding");
+                if let Ok(bytes) = embedding_bytes_res {
+                     match bytes_to_f32_vec(&bytes) {
+                         Ok(vec) => Some(vec),
+                         Err(e) => {
+                             eprintln!("Failed to deserialize VSS embedding bytes for rowid {}: {}", swatch_rowid, e);
+                             None
+                         }
+                     }
+                } else {
+                     eprintln!(
+                         "Failed to retrieve VSS embedding as bytes for rowid {}: {}",
+                         swatch_rowid, embedding_bytes_res.unwrap_err()
+                     );
+                     None
+                }
+            }
+            Ok(None) => None,
+            Err(e) => {
+                eprintln!(
+                    "Error fetching VSS embedding from query for rowid {}: {}",
+                    swatch_rowid, e
+                );
+                None
+            }
+        }
+    }
+    
     #[tokio::test]
     async fn test_save_and_get_swatch() {
         let pool = setup().await;
         let swatch_repo = SqliteSwatchRepository::new(pool.clone());
-        let (_material_repo, _cuts_repo, material_id, cut_id) =
-            insert_test_dependencies(&pool, "save-get", 0).await;
-
+        let (_material_repo, _cuts_repo, material_id, cut_id) = insert_test_dependencies(&pool, "save-get", 0).await;
         let swatch = create_test_swatch(&cut_id, &material_id);
+        let swatch_id = swatch.id.clone();
+        let original_embedding = swatch.embedding.clone();
 
-        swatch_repo
-            .save_swatch(&swatch)
-            .await
-            .expect("Failed to save");
+        // Save the swatch
+        let save_result = swatch_repo.save_swatch(&swatch).await;
+        assert!(save_result.is_ok(), "Save failed: {:?}", save_result.err());
 
-        let retrieved_swatch = swatch_repo
-            .get_swatch_by_id(&swatch.id)
-            .await
-            .expect("Failed to get")
-            .expect("Swatch not found");
+        // Retrieve the swatch by ID
+        let retrieved = swatch_repo.get_swatch_by_id(&swatch_id).await;
+        assert!(retrieved.is_ok(), "Get failed: {:?}", retrieved.err());
+        let retrieved_swatch = retrieved.unwrap().expect("Swatch not found after save");
+        assert_eq!(retrieved_swatch.id, swatch_id);
+        assert_eq!(retrieved_swatch.embedding, original_embedding);
 
-        // Compare fields individually
-        assert_eq!(retrieved_swatch.id, swatch.id);
-        assert_eq!(retrieved_swatch.cut_id, cut_id);
-        assert_eq!(retrieved_swatch.material_id, material_id);
-        assert_eq!(retrieved_swatch.embedding, swatch.embedding);
-        assert_eq!(retrieved_swatch.model_name, swatch.model_name);
-        assert_eq!(retrieved_swatch.model_version, swatch.model_version);
-        assert_eq!(retrieved_swatch.dimensions, swatch.dimensions);
-        assert!(retrieved_swatch.metadata.is_none()); // Metadata is none in base helper
-        assert_eq!(retrieved_swatch.similarity_threshold, Some(0.85)); // Check threshold
-                                                                       // Allow a small tolerance for timestamp comparison
-        assert!((retrieved_swatch.created_at - swatch.created_at).abs() < Duration::seconds(1));
+        // Verify VSS table entry
+        let rowid_result = sqlx::query("SELECT rowid FROM swatches WHERE id = ?")
+            .bind(&swatch_id)
+            .fetch_one(&pool)
+            .await;
+        assert!(rowid_result.is_ok(), "Failed to get rowid: {:?}", rowid_result.err());
+        let rowid: i64 = rowid_result.unwrap().get("rowid");
+
+        let vss_embedding = get_vss_embedding(&pool, rowid).await;
+        assert!(vss_embedding.is_some(), "VSS embedding not found for rowid {}", rowid);
+        assert_eq!(vss_embedding.unwrap(), original_embedding, "VSS embedding does not match original");
     }
 
     #[tokio::test]
@@ -816,40 +905,52 @@ mod tests {
     async fn test_save_swatch_upsert() {
         let pool = setup().await;
         let swatch_repo = SqliteSwatchRepository::new(pool.clone());
-        let (_material_repo, _cuts_repo, material_id, cut_id) =
-            insert_test_dependencies(&pool, "upsert", 0).await;
+        let (_material_repo, _cuts_repo, material_id, cut_id) = insert_test_dependencies(&pool, "upsert", 0).await;
+        let mut swatch1 = create_test_swatch(&cut_id, &material_id);
+        let swatch_id = swatch1.id.clone(); // Use the same ID for both
+        let original_embedding = swatch1.embedding.clone();
 
-        let mut swatch = create_test_swatch(&cut_id, &material_id);
-        swatch.similarity_threshold = Some(0.7); // Initial threshold
+        // Save the first version
+        let save1_result = swatch_repo.save_swatch(&swatch1).await;
+        assert!(save1_result.is_ok(), "Save 1 failed: {:?}", save1_result.err());
 
-        // Initial save
-        swatch_repo
-            .save_swatch(&swatch)
-            .await
-            .expect("Initial save failed");
+        // Verify VSS after first save
+        let rowid_result1 = sqlx::query("SELECT rowid FROM swatches WHERE id = ?")
+            .bind(&swatch_id)
+            .fetch_one(&pool)
+            .await;
+        assert!(rowid_result1.is_ok(), "Failed to get rowid 1: {:?}", rowid_result1.err());
+        let rowid1: i64 = rowid_result1.unwrap().get("rowid");
+        
+        let vss_embedding1 = get_vss_embedding(&pool, rowid1).await;
+        assert!(vss_embedding1.is_some(), "VSS embedding not found after first save for rowid {}", rowid1);
+        assert_eq!(vss_embedding1.unwrap(), original_embedding, "VSS embedding does not match original after first save");
 
-        // Modify and save again (upsert)
-        swatch.model_version = "v1.1".to_string();
-        swatch.embedding = vec![0.4, 0.5];
-        swatch.dimensions = swatch.embedding.len();
-        swatch.similarity_threshold = Some(0.75); // Update threshold
+        // Modify the swatch (e.g., change embedding)
+        let updated_embedding = vec![0.9; 384]; // Use 384 dimensions
+        swatch1.embedding = updated_embedding.clone();
 
-        swatch_repo
-            .save_swatch(&swatch)
-            .await
-            .expect("Upsert save failed");
+        // Save the second version (upsert)
+        let save2_result = swatch_repo.save_swatch(&swatch1).await;
+        assert!(save2_result.is_ok(), "Save 2 failed: {:?}", save2_result.err());
 
-        let retrieved_swatch = swatch_repo
-            .get_swatch_by_id(&swatch.id)
-            .await
-            .expect("Failed to get after upsert")
-            .expect("Swatch not found after upsert");
+        // Retrieve the updated swatch
+        let retrieved = swatch_repo.get_swatch_by_id(&swatch_id).await.unwrap().unwrap();
+        assert_eq!(retrieved.id, swatch_id);
+        assert_eq!(retrieved.embedding, updated_embedding, "Swatch embedding was not updated");
+        
+        // Verify VSS after second save (should use same rowid)
+         let rowid_result2 = sqlx::query("SELECT rowid FROM swatches WHERE id = ?")
+            .bind(&swatch_id)
+            .fetch_one(&pool)
+            .await;
+        assert!(rowid_result2.is_ok(), "Failed to get rowid 2: {:?}", rowid_result2.err());
+        let rowid2: i64 = rowid_result2.unwrap().get("rowid");
+        assert_eq!(rowid2, rowid1, "Rowid changed during upsert"); // Ensure rowid remains stable
 
-        assert_eq!(retrieved_swatch.id, swatch.id);
-        assert_eq!(retrieved_swatch.model_version, "v1.1");
-        assert_eq!(retrieved_swatch.embedding, vec![0.4, 0.5]);
-        assert_eq!(retrieved_swatch.dimensions, 2);
-        assert_eq!(retrieved_swatch.similarity_threshold, Some(0.75)); // Check updated threshold
+        let vss_embedding2 = get_vss_embedding(&pool, rowid2).await;
+        assert!(vss_embedding2.is_some(), "VSS embedding not found after second save for rowid {}", rowid2);
+        assert_eq!(vss_embedding2.unwrap(), updated_embedding, "VSS embedding does not match updated embedding after second save");
     }
 
     #[tokio::test]

--- a/src/swatching/sqlite_repository.rs
+++ b/src/swatching/sqlite_repository.rs
@@ -315,8 +315,6 @@ impl SqliteSwatchRepository {
         metadata_json: &Option<String>,
         similarity_threshold: Option<f32>,
     ) -> std::result::Result<sqlx::sqlite::SqliteQueryResult, sqlx::Error> {
-        
-
         sqlx::query(
             r#"
             INSERT INTO swatches (
@@ -741,7 +739,6 @@ mod tests {
     use crate::db::init_memory_db;
     use crate::materials::{Material, MaterialRepository, SqliteMaterialRepository};
     use serde_json::json;
-    
 
     // Helper to create a test pool
     async fn setup() -> SqlitePool {


### PR DESCRIPTION
Implements the vector table (`vss_swatches`) integration specifically for the `SwatchRepository::save_swatch` method.

- Modifies `save_swatch` to perform `DELETE` then `INSERT` operations on `vss_swatches` using the correct integer `rowid` within the same transaction as the main `swatches` table update.
- Ensures VSS operations use the correct embedding data format (serialized bytes).
- Implements non-fatal error handling for VSS operations (logs errors via `debug!`, does not roll back the main transaction).
- Updates tests for `save_swatch` and `save_swatch_upsert` to verify the state of `vss_swatches` after successful saves, using correct embedding dimensions (384).

Fixes #29
